### PR TITLE
refactor(attestor): update naming and attestor url

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ node node_modules/@reclaimprotocol/zk-symmetric-crypto/lib/scripts/download-file
 
 ## Prerequisites
 
+- Node.js version 18 or higher
 - An application ID and secret from the [Reclaim Developer Portal](https://dev.reclaimprotocol.org/)
+
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "madhavanmalolan",
   "license": "SEE LICENSE IN https://github.com/reclaimprotocol/zk-fetch/blob/master/LICENSE.md",
   "dependencies": {
-    "@reclaimprotocol/attestor-core": "git+https://github.com/reclaimprotocol/attestor-core",
+    "@reclaimprotocol/attestor-core": "4.0.0",
     "@swc/core": "^1.6.13",
     "ethers": "^5.7.2",
     "pino": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "madhavanmalolan",
   "license": "SEE LICENSE IN https://github.com/reclaimprotocol/zk-fetch/blob/master/LICENSE.md",
   "dependencies": {
-    "@reclaimprotocol/attestor-core": "3.1.1",
+    "@reclaimprotocol/attestor-core": "git+https://github.com/reclaimprotocol/attestor-core",
     "@swc/core": "^1.6.13",
     "ethers": "^5.7.2",
     "pino": "^8.20.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 const LOGS_BACKEND_URL = "https://logs.reclaimprotocol.org"
 const APP_BACKEND_URL = "https://api.reclaimprotocol.org"
-const WITNESS_NODE_URL = "wss://attestor.reclaimprotocol.org/ws"
+const ATTESTOR_NODE_URL = "wss://attestor.reclaimprotocol.org:447/ws"
 
 
-export { LOGS_BACKEND_URL, APP_BACKEND_URL, WITNESS_NODE_URL }
+export { LOGS_BACKEND_URL, APP_BACKEND_URL, ATTESTOR_NODE_URL }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { ApplicationError, InvalidMethodError, InvalidParamError, NetworkError }
 import { ApplicationId, ApplicationSecret, HttpMethod } from './types'
 import { Options, Proof, SendLogsParams } from './interfaces';
 import { ethers } from 'ethers';
-import { APP_BACKEND_URL, LOGS_BACKEND_URL, WITNESS_NODE_URL } from './constants';
+import { APP_BACKEND_URL, LOGS_BACKEND_URL, ATTESTOR_NODE_URL } from './constants';
 import P from "pino";
 import { ClaimTunnelResponse } from '@reclaimprotocol/attestor-core/lib/proto/api';
 const logger = P();
@@ -71,7 +71,7 @@ export function transformProof(proof: ClaimTunnelResponse): Proof {
     witnesses: [
       {
         id: proof?.signatures?.attestorAddress,
-        url: WITNESS_NODE_URL,
+        url: ATTESTOR_NODE_URL,
       },
     ],
   };

--- a/src/zkfetch.ts
+++ b/src/zkfetch.ts
@@ -10,7 +10,7 @@ import {
 } from "./utils";
 import { v4 } from "uuid";
 import P from "pino";
-import { WITNESS_NODE_URL } from "./constants";
+import { ATTESTOR_NODE_URL } from "./constants";
 const logger = P();
 
 export class ReclaimClient {
@@ -81,11 +81,11 @@ export class ReclaimClient {
           ownerPrivateKey: this.applicationSecret,
           logger: logger,
           client: {
-            url: WITNESS_NODE_URL,
+            url: ATTESTOR_NODE_URL,
           },
         });
         if (claim.error) {
-          throw new Error(`Failed to create claim on witness: ${claim.error.message}`);
+          throw new Error(`Failed to create claim on attestor: ${claim.error.message}`);
         }
 
         await sendLogs({

--- a/tests/getEthPrice.test.ts
+++ b/tests/getEthPrice.test.ts
@@ -1,15 +1,25 @@
 import { getEthPrice } from './getEthPrice';
-import { expect, test } from 'vitest'
+import { expect, test, describe } from 'vitest'
 
-test('extractedParameterValues', async () => {
-    const ethPriceProof = await getEthPrice();
-    expect(parseFloat(ethPriceProof?.extractedParameterValues?.price)).toBeGreaterThan(0);
-}, 100000);
-
-
-test('context', async () => {
+describe('ETH Price Tests', () => {
+  test('should return valid context data', async () => {
     const ethPriceProof = await getEthPrice();
     const context = JSON.parse(ethPriceProof?.claimData?.context || "{}");
-    expect(context?.contextAddress).toContain("0x0000000000000000000000000000000000000000");
-    expect(context?.contextMessage).toContain("eth_price");
-}, 100000);
+    
+    expect(context).toBeDefined();
+    expect(context.contextAddress).toBeDefined();
+    expect(context.contextAddress).toContain("0x0000000000000000000000000000000000000000");
+    expect(context.contextMessage).toBeDefined();
+    expect(context.contextMessage).toContain("eth_price");
+  }, 100000);
+
+  test('should return ETH price', async () => {
+    const ethPriceProof = await getEthPrice();
+    const price = parseFloat(ethPriceProof?.extractedParameterValues?.price);
+    
+    expect(ethPriceProof).toBeDefined();
+    expect(ethPriceProof?.extractedParameterValues).toBeDefined();
+    expect(price).toBeDefined();
+    expect(price).toBeGreaterThan(0);
+  }, 100000);
+});


### PR DESCRIPTION
Standardize attestor naming convention and update url 
configuration for better maintainability.

What & Why:
- Rename WITNESS_NODE_URL to ATTESTOR_NODE_URL for consistency
- Update attestor url
- Add Node.js v18+ requirement to prevent runtime issues
- Improve test cases

Checklist:
- [x] Renamed all witness references to attestor
- [x] Updated attestor URLs
- [x] Improved test cases
- [x] Updated docs