### PR TITLE
chore: bump attestor-core dependency to version 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "madhavanmalolan",
   "license": "SEE LICENSE IN https://github.com/reclaimprotocol/zk-fetch/blob/master/LICENSE.md",
   "dependencies": {
-    "@reclaimprotocol/attestor-core": "4.0.0",
+    "@reclaimprotocol/attestor-core": "4.0.1",
     "@swc/core": "^1.6.13",
     "ethers": "^5.7.2",
     "pino": "^8.20.0",


### PR DESCRIPTION
Update package-lock.json and package.json to use the latest attestor-core version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the dependency to improve overall stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->